### PR TITLE
linux-files: añadido setup.sh en devasc_eval

### DIFF
--- a/devasc_eval/setup.sh
+++ b/devasc_eval/setup.sh
@@ -1,0 +1,14 @@
+#hola xd prueba 1234 probando 
+DIR="$HOME/Documentos/devasc_eval"
+mkdir -p "$DIR"
+
+FILE="$DIR/prueba.txt"
+echo "Contenido de prueba" > "$FILE"
+
+#permisos
+chmod 744 "$FILE"
+
+#cambiar propietario a root
+sudo chown root:root "$FILE"
+
+


### PR DESCRIPTION
Este PR añade el script setup.sh para:
- Crear /Documentos/devasc_eval
- Generar prueba.txt con permisos 744
- Cambiar propietario a root
